### PR TITLE
Amount input refactor for the PR '42 add confirmation page'

### DIFF
--- a/src/views/home/components/amount-input/amount-input.view.tsx
+++ b/src/views/home/components/amount-input/amount-input.view.tsx
@@ -8,7 +8,7 @@ import { Token } from "src/domain";
 
 interface onChangeParams {
   amount?: BigNumber;
-  isInvalid: boolean;
+  error?: string;
 }
 
 interface AmountInputProps {
@@ -34,16 +34,14 @@ const AmountInput: FC<AmountInputProps> = ({ value, token, balance, fee, onChang
     if (amount) {
       const newAmountWithFee = amount.add(actualFee);
       const isNewAmountWithFeeMoreThanFunds = newAmountWithFee.gt(BigNumber.from(balance));
-      const isAmountInvalid = isNewAmountWithFeeMoreThanFunds || amount.isZero();
-      onChange({
-        amount,
-        isInvalid: isAmountInvalid,
-      });
+      const error = isNewAmountWithFeeMoreThanFunds
+        ? "Insufficient balance"
+        : amount.isZero()
+        ? "The amount should be greater than 0"
+        : undefined;
+      onChange({ amount, error });
     } else {
-      onChange({
-        amount: undefined,
-        isInvalid: false,
-      });
+      onChange({});
     }
   };
 

--- a/src/views/home/components/amount-input/amount-input.view.tsx
+++ b/src/views/home/components/amount-input/amount-input.view.tsx
@@ -33,7 +33,7 @@ const AmountInput: FC<AmountInputProps> = ({ value, token, balance, fee, onChang
   const updateAmountInput = (amount?: BigNumber) => {
     if (amount) {
       const newAmountWithFee = amount.add(actualFee);
-      const isNewAmountWithFeeMoreThanFunds = newAmountWithFee.gt(BigNumber.from(balance));
+      const isNewAmountWithFeeMoreThanFunds = newAmountWithFee.gt(balance);
       const error = isNewAmountWithFeeMoreThanFunds ? "Insufficient balance" : undefined;
       onChange({ amount, error });
     } else {

--- a/src/views/home/components/amount-input/amount-input.view.tsx
+++ b/src/views/home/components/amount-input/amount-input.view.tsx
@@ -25,8 +25,8 @@ const getFixedTokenAmount = (amount: string, decimals: number): string => {
 };
 
 const AmountInput: FC<AmountInputProps> = ({ value, token, balance, fee, onChange }) => {
-  const defaultValue = value ? getFixedTokenAmount(value.toString(), token.decimals) : "";
-  const [inputValue, setInputValue] = useState(defaultValue);
+  const defaultInputValue = value ? getFixedTokenAmount(value.toString(), token.decimals) : "";
+  const [inputValue, setInputValue] = useState(defaultInputValue);
   const classes = useAmountInputStyles(inputValue.length);
   const actualFee = token.symbol === "WETH" ? fee : BigNumber.from(0);
 

--- a/src/views/home/components/amount-input/amount-input.view.tsx
+++ b/src/views/home/components/amount-input/amount-input.view.tsx
@@ -1,4 +1,4 @@
-import { BigNumber } from "ethers";
+import { BigNumber, constants as ethersConstants } from "ethers";
 import { parseUnits } from "ethers/lib/utils";
 import { ChangeEvent, FC, useState } from "react";
 
@@ -28,7 +28,7 @@ const AmountInput: FC<AmountInputProps> = ({ value, token, balance, fee, onChang
   const defaultInputValue = value ? getFixedTokenAmount(value.toString(), token.decimals) : "";
   const [inputValue, setInputValue] = useState(defaultInputValue);
   const classes = useAmountInputStyles(inputValue.length);
-  const actualFee = token.symbol === "WETH" ? fee : BigNumber.from(0);
+  const actualFee = token.address === ethersConstants.AddressZero ? fee : BigNumber.from(0);
 
   const updateAmountInput = (amount?: BigNumber) => {
     if (amount) {

--- a/src/views/home/components/amount-input/amount-input.view.tsx
+++ b/src/views/home/components/amount-input/amount-input.view.tsx
@@ -34,11 +34,7 @@ const AmountInput: FC<AmountInputProps> = ({ value, token, balance, fee, onChang
     if (amount) {
       const newAmountWithFee = amount.add(actualFee);
       const isNewAmountWithFeeMoreThanFunds = newAmountWithFee.gt(BigNumber.from(balance));
-      const error = isNewAmountWithFeeMoreThanFunds
-        ? "Insufficient balance"
-        : amount.isZero()
-        ? "The amount should be greater than 0"
-        : undefined;
+      const error = isNewAmountWithFeeMoreThanFunds ? "Insufficient balance" : undefined;
       onChange({ amount, error });
     } else {
       onChange({});
@@ -46,16 +42,19 @@ const AmountInput: FC<AmountInputProps> = ({ value, token, balance, fee, onChang
   };
 
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
     const decimals = token.decimals;
     const regexToken = `^(?!0\\d|\\.)\\d*(?:\\.\\d{0,${decimals}})?$`;
     const INPUT_REGEX = new RegExp(regexToken);
+    const isInputValid = INPUT_REGEX.test(value);
 
     const newAmountInTokens =
-      INPUT_REGEX.test(event.target.value) && event.target.value.length > 0
-        ? parseUnits(event.target.value, token.decimals)
-        : undefined;
-    setInputValue(event.target.value);
-    updateAmountInput(newAmountInTokens);
+      value.length > 0 && isInputValid ? parseUnits(value, token.decimals) : undefined;
+
+    if (isInputValid) {
+      updateAmountInput(newAmountInTokens);
+      setInputValue(value);
+    }
   };
 
   const handleSendAll = () => {

--- a/src/views/home/components/transaction-form/transaction-form.view.tsx
+++ b/src/views/home/components/transaction-form/transaction-form.view.tsx
@@ -61,7 +61,7 @@ const TransactionForm: FC = () => {
   };
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (localTransaction && localTransaction.amount) {
+    if (localTransaction.amount) {
       setTransaction({
         ...localTransaction,
         amount: localTransaction.amount,
@@ -138,7 +138,12 @@ const TransactionForm: FC = () => {
         </div>
       </Card>
       <div className={classes.button}>
-        <Button type="submit" disabled={!localTransaction.amount || localTransaction.amount.isZero() || error !== undefined}>
+        <Button
+          type="submit"
+          disabled={
+            !localTransaction.amount || localTransaction.amount.isZero() || error !== undefined
+          }
+        >
           Continue
         </Button>
         {localTransaction.amount && error && <Error error={error} />}

--- a/src/views/home/components/transaction-form/transaction-form.view.tsx
+++ b/src/views/home/components/transaction-form/transaction-form.view.tsx
@@ -36,7 +36,7 @@ const TransactionForm: FC = () => {
   const classes = useTransactionFormtStyles();
   const [list, setList] = useState<List>();
   const { transaction, setTransaction } = useTransactionContext();
-  const [isInvalid, setIsInvalid] = useState(false);
+  const [error, setError] = useState<string>();
   const navigate = useNavigate();
   const [localTransaction, setLocalTransaction] = useState(transaction || defaultTransaction);
   const ChainFromIcon = localTransaction.from.icon;
@@ -55,9 +55,9 @@ const TransactionForm: FC = () => {
     setList(undefined);
   };
 
-  const onInputChange = ({ amount, isInvalid }: { amount?: BigNumber; isInvalid: boolean }) => {
+  const onInputChange = ({ amount, error }: { amount?: BigNumber; error?: string }) => {
     setLocalTransaction({ ...localTransaction, amount });
-    setIsInvalid(isInvalid);
+    setError(error);
   };
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -138,10 +138,10 @@ const TransactionForm: FC = () => {
         </div>
       </Card>
       <div className={classes.button}>
-        <Button type="submit" disabled={!localTransaction.amount || isInvalid}>
+        <Button type="submit" disabled={!localTransaction.amount || error !== undefined}>
           Continue
         </Button>
-        {localTransaction.amount && isInvalid && <Error error="Insufficient balance" />}
+        {localTransaction.amount && error && <Error error={error} />}
       </div>
       {list && (
         <List

--- a/src/views/home/components/transaction-form/transaction-form.view.tsx
+++ b/src/views/home/components/transaction-form/transaction-form.view.tsx
@@ -16,23 +16,29 @@ import Button from "src/views/shared/button/button.view";
 import AmountInput from "src/views/home/components/amount-input/amount-input.view";
 import { chains } from "src/constants";
 import { useTransactionContext } from "src/contexts/transaction.context";
-import { Chain, Token, TransactionData } from "src/domain";
+import { Chain, Token } from "src/domain";
 import routes from "src/routes";
+
+export interface TransactionData {
+  from: Chain;
+  to: Chain;
+  token: Token;
+  amount?: BigNumber;
+}
 
 const defaultTransaction: TransactionData = {
   from: chains[0],
   to: chains[1],
   token: tokens[0],
-  amount: BigNumber.from(0),
 };
 
 const TransactionForm: FC = () => {
   const classes = useTransactionFormtStyles();
   const [list, setList] = useState<List>();
-  const { setTransaction } = useTransactionContext();
-  const [isInvalid, setIsInvalid] = useState(true);
+  const { transaction, setTransaction } = useTransactionContext();
+  const [isInvalid, setIsInvalid] = useState(false);
   const navigate = useNavigate();
-  const [localTransaction, setLocalTransaction] = useState(defaultTransaction);
+  const [localTransaction, setLocalTransaction] = useState(transaction || defaultTransaction);
   const ChainFromIcon = localTransaction.from.icon;
   const ChainToIcon = localTransaction.to.icon;
 
@@ -49,13 +55,18 @@ const TransactionForm: FC = () => {
     setList(undefined);
   };
 
-  const onInputChange = ({ amount, isInvalid }: { amount: BigNumber; isInvalid: boolean }) => {
+  const onInputChange = ({ amount, isInvalid }: { amount?: BigNumber; isInvalid: boolean }) => {
     setLocalTransaction({ ...localTransaction, amount });
     setIsInvalid(isInvalid);
   };
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    setTransaction(localTransaction);
+    if (localTransaction && localTransaction.amount) {
+      setTransaction({
+        ...localTransaction,
+        amount: localTransaction.amount,
+      });
+    }
     navigate(routes.confirmation.path);
   };
 
@@ -92,6 +103,7 @@ const TransactionForm: FC = () => {
             <CaretDown className={classes.icons} />
           </button>
           <AmountInput
+            value={localTransaction.amount}
             token={localTransaction.token}
             balance={BigNumber.from(parseUnits("2.0", localTransaction.token.decimals))}
             fee={BigNumber.from(parseUnits("0.0001", localTransaction.token.decimals))}
@@ -126,10 +138,10 @@ const TransactionForm: FC = () => {
         </div>
       </Card>
       <div className={classes.button}>
-        <Button type="submit" disabled={isInvalid}>
+        <Button type="submit" disabled={!localTransaction.amount || isInvalid}>
           Continue
         </Button>
-        {isInvalid && !localTransaction.amount.isZero() && <Error error="Insufficient balance" />}
+        {localTransaction.amount && isInvalid && <Error error="Insufficient balance" />}
       </div>
       {list && (
         <List

--- a/src/views/home/components/transaction-form/transaction-form.view.tsx
+++ b/src/views/home/components/transaction-form/transaction-form.view.tsx
@@ -138,7 +138,7 @@ const TransactionForm: FC = () => {
         </div>
       </Card>
       <div className={classes.button}>
-        <Button type="submit" disabled={!localTransaction.amount || error !== undefined}>
+        <Button type="submit" disabled={!localTransaction.amount || localTransaction.amount.isZero() || error !== undefined}>
           Continue
         </Button>
         {localTransaction.amount && error && <Error error={error} />}


### PR DESCRIPTION
This PR implements a mechanism to recover the data of the user when the TX confirmation screen is closed, so the user can edit the wrong data and try again.

It also removes some wrong assumptions:

* Avoid assuming `0` as the default value for the default `TransactionData` in favor of `undefined`.
* Allow `undefined` as a valid value for the `amount-input` view onChange event.