### PR TITLE
Only show tokens that belong to the network selected in from

### DIFF
--- a/src/adapters/env.ts
+++ b/src/adapters/env.ts
@@ -1,14 +1,8 @@
 import { z } from "zod";
-import { ethers } from "ethers";
 
 import { StrictSchema } from "src/utils/type-safety";
 import * as domain from "src/domain";
-import {
-  getChains,
-  getUsdtToken,
-  getSupportedERC20Tokens,
-  ETH_TOKEN_LOGO_URI,
-} from "src/constants";
+import { getChains, getUsdtToken } from "src/constants";
 
 interface Env {
   REACT_APP_ETHEREUM_RPC_URL: string;
@@ -78,17 +72,6 @@ const envToDomain = ({
         usdtToken: getUsdtToken({ address: REACT_APP_USDT_ADDRESS, chainId: usdtChainId }),
       },
       chains,
-      tokens: [
-        {
-          name: "Ether",
-          address: ethers.constants.AddressZero,
-          chainId,
-          symbol: "ETH",
-          decimals: 18,
-          logoURI: ETH_TOKEN_LOGO_URI,
-        },
-        ...getSupportedERC20Tokens(chains),
-      ],
       version: REACT_APP_VERSION,
     };
   });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,4 @@
+import { ethers } from "ethers";
 import { JsonRpcProvider } from "@ethersproject/providers";
 
 import { Chain, Currency, Token } from "src/domain";
@@ -73,10 +74,17 @@ export const getChains = ({
   );
 };
 
-export const getSupportedERC20Tokens = ([l1, l2]: [Chain, Chain]): Token[] => {
-  const tokens = erc20Tokens.filter(
-    (token) => token.chainId === l1.chainId || token.chainId === l2.chainId
-  );
+export const getChainTokens = (chain: Chain): Token[] => {
+  const etherToken: Token = {
+    name: "Ether",
+    address: ethers.constants.AddressZero,
+    chainId: chain.chainId,
+    symbol: "ETH",
+    decimals: 18,
+    logoURI: ETH_TOKEN_LOGO_URI,
+  };
+  const chainErc20Tokens: Token[] = erc20Tokens.filter((token) => token.chainId === chain.chainId);
+  const tokens = [etherToken, ...chainErc20Tokens];
   cleanupCustomTokens(tokens);
   return tokens;
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -74,8 +74,8 @@ export const getChains = ({
   );
 };
 
-export const getChainTokens = (chain: Chain): Token[] => {
-  const etherToken: Token = {
+export const getEtherToken = (chain: Chain): Token => {
+  return {
     name: "Ether",
     address: ethers.constants.AddressZero,
     chainId: chain.chainId,
@@ -83,8 +83,11 @@ export const getChainTokens = (chain: Chain): Token[] => {
     decimals: 18,
     logoURI: ETH_TOKEN_LOGO_URI,
   };
+};
+
+export const getChainTokens = (chain: Chain): Token[] => {
   const chainErc20Tokens: Token[] = erc20Tokens.filter((token) => token.chainId === chain.chainId);
-  const tokens = [etherToken, ...chainErc20Tokens];
+  const tokens = [getEtherToken(chain), ...chainErc20Tokens];
   cleanupCustomTokens(tokens);
   return tokens;
 };

--- a/src/contexts/bridge.context.tsx
+++ b/src/contexts/bridge.context.tsx
@@ -325,16 +325,7 @@ const BridgeProvider: FC = (props) => {
         token.address === ethersConstants.AddressZero ? { value: amount } : {};
 
       const executeBridge = async () => {
-        const doesTokenMatchNetwork = token.chainId === from.chainId;
         const isTokenEther = token.address === ethersConstants.AddressZero;
-        const tokenAddress =
-          doesTokenMatchNetwork || isTokenEther
-            ? token.address
-            : await getWrappedTokenAddress({
-                token,
-                from,
-                to,
-              });
 
         if (!isTokenEther) {
           if (account.status !== "successful") {
@@ -342,7 +333,7 @@ const BridgeProvider: FC = (props) => {
           }
 
           const erc20Contract = Erc20__factory.connect(
-            tokenAddress,
+            token.address,
             connectedProvider.provider.getSigner()
           );
           const allowance = await erc20Contract.allowance(account.data, from.contractAddress);
@@ -350,7 +341,7 @@ const BridgeProvider: FC = (props) => {
             await erc20Contract.approve(from.contractAddress, amount);
           }
         }
-        return contract.bridge(tokenAddress, amount, to.networkId, destinationAddress, overrides);
+        return contract.bridge(token.address, amount, to.networkId, destinationAddress, overrides);
       };
 
       if (from.chainId === connectedProvider?.chainId) {

--- a/src/contexts/bridge.context.tsx
+++ b/src/contexts/bridge.context.tsx
@@ -27,10 +27,9 @@ interface GetTokenFromAddressParams {
 }
 
 interface GetErc20TokenBalanceParams {
-  token: Token;
-  from: Chain;
-  to: Chain;
-  ethereumAddress: string;
+  chain: Chain;
+  tokenAddress: string;
+  accountAddress: string;
 }
 
 interface EstimateBridgeGasPriceParams {
@@ -419,28 +418,16 @@ const BridgeProvider: FC = (props) => {
   );
 
   const getErc20TokenBalance = async ({
-    token,
-    from,
-    to,
-    ethereumAddress,
+    chain,
+    tokenAddress,
+    accountAddress,
   }: GetErc20TokenBalanceParams) => {
-    const isTokenEther = token.address === ethersConstants.AddressZero;
+    const isTokenEther = tokenAddress === ethersConstants.AddressZero;
     if (isTokenEther) {
       return Promise.reject(new Error("Ether is not supported as ERC20 token"));
     }
-    const doesTokenMatchNetwork = token.chainId === from.chainId;
-
-    const tokenAddress = doesTokenMatchNetwork
-      ? token.address
-      : await getWrappedTokenAddress({
-          token,
-          from,
-          to,
-        });
-
-    const erc20Contract = Erc20__factory.connect(tokenAddress, from.provider);
-    const balance = await erc20Contract.balanceOf(ethereumAddress);
-    return balance;
+    const erc20Contract = Erc20__factory.connect(tokenAddress, chain.provider);
+    return await erc20Contract.balanceOf(accountAddress);
   };
 
   const getWrappedTokenAddress = async ({

--- a/src/contexts/bridge.context.tsx
+++ b/src/contexts/bridge.context.tsx
@@ -46,8 +46,8 @@ interface GetBridgesParams {
 
 interface GetWrappedTokenAddressParams {
   token: Token;
-  from: Chain;
-  to: Chain;
+  nativeTokenChain: Chain;
+  wrappedTokenChain: Chain;
 }
 
 interface BridgeParams {
@@ -432,14 +432,17 @@ const BridgeProvider: FC = (props) => {
 
   const getWrappedTokenAddress = async ({
     token,
-    from,
-    to,
+    nativeTokenChain,
+    wrappedTokenChain,
   }: GetWrappedTokenAddressParams): Promise<string> => {
-    const bridgeContract = Bridge__factory.connect(from.contractAddress, from.provider);
+    const bridgeContract = Bridge__factory.connect(
+      wrappedTokenChain.contractAddress,
+      wrappedTokenChain.provider
+    );
     const tokenImplementationAddress = await bridgeContract.tokenImplementation();
     const salt = ethers.utils.solidityKeccak256(
       ["uint32", "address"],
-      [to.networkId, token.address]
+      [nativeTokenChain.networkId, token.address]
     );
     // Bytecode proxy from this blog https://blog.openzeppelin.com/deep-dive-into-the-minimal-proxy-contract/
     const minimalBytecodeProxy = `0x3d602d80600a3d3981f3363d3d373d3d3d363d73${tokenImplementationAddress.slice(

--- a/src/contexts/bridge.context.tsx
+++ b/src/contexts/bridge.context.tsx
@@ -12,7 +12,7 @@ import { createContext, FC, useContext, useCallback } from "react";
 import { useProvidersContext } from "src/contexts/providers.context";
 import { Bridge__factory } from "src/types/contracts/bridge";
 import { Erc20__factory } from "src/types/contracts/erc-20";
-import { BRIDGE_CALL_GAS_INCREASE_PERCENTAGE } from "src/constants";
+import { BRIDGE_CALL_GAS_INCREASE_PERCENTAGE, getEtherToken } from "src/constants";
 import { calculateFee } from "src/utils/fees";
 import { useEnvContext } from "src/contexts/env.context";
 import tokenIconDefaultUrl from "src/assets/icons/tokens/erc20-icon.svg";
@@ -180,13 +180,15 @@ const BridgeProvider: FC = (props) => {
     env,
     tokenAddress,
     originNetwork,
+    chain,
   }: {
     env: Env;
     tokenAddress: string;
     originNetwork: number;
+    chain: Chain;
   }): Promise<Token> => {
     const error = `The specified token_addr "${tokenAddress}" can not be found in the list of supported Tokens`;
-    const token = [...getCustomTokens(), ...erc20Tokens].find(
+    const token = [...getCustomTokens(), getEtherToken(chain), ...erc20Tokens].find(
       (token) => token.address === tokenAddress
     );
     if (token) {
@@ -237,7 +239,12 @@ const BridgeProvider: FC = (props) => {
           );
         }
 
-        const token = await getToken({ env, tokenAddress: token_addr, originNetwork: orig_net });
+        const token = await getToken({
+          env,
+          tokenAddress: token_addr,
+          originNetwork: orig_net,
+          chain: networkId,
+        });
 
         const deposit: Deposit = {
           token,

--- a/src/contexts/bridge.context.tsx
+++ b/src/contexts/bridge.context.tsx
@@ -19,6 +19,7 @@ import tokenIconDefaultUrl from "src/assets/icons/tokens/erc20-icon.svg";
 import { getDeposits, getClaims, getClaimStatus, getMerkleProof } from "src/adapters/bridge-api";
 import { getCustomTokens } from "src/adapters/storage";
 import { Env, Chain, Token, Bridge, Deposit } from "src/domain";
+import { erc20Tokens } from "src/erc20-tokens";
 
 interface GetTokenFromAddressParams {
   address: string;
@@ -185,7 +186,7 @@ const BridgeProvider: FC = (props) => {
     originNetwork: number;
   }): Promise<Token> => {
     const error = `The specified token_addr "${tokenAddress}" can not be found in the list of supported Tokens`;
-    const token = [...getCustomTokens(), ...env.tokens].find(
+    const token = [...getCustomTokens(), ...erc20Tokens].find(
       (token) => token.address === tokenAddress
     );
     if (token) {

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -32,7 +32,6 @@ export interface Env {
     usdtToken: Token;
   };
   chains: [Chain, Chain];
-  tokens: Token[];
   version: string;
 }
 

--- a/src/views/home/components/bridge-form/bridge-form.view.tsx
+++ b/src/views/home/components/bridge-form/bridge-form.view.tsx
@@ -42,7 +42,8 @@ const BridgeForm: FC<BridgeFormProps> = ({ account, formData, resetForm, onSubmi
   const classes = useBridgeFormStyles();
   const env = useEnvContext();
   const { notifyError } = useErrorContext();
-  const { estimateBridgeGasPrice, getErc20TokenBalance } = useBridgeContext();
+  const { estimateBridgeGasPrice, getErc20TokenBalance, getWrappedTokenAddress } =
+    useBridgeContext();
   const { connectedProvider } = useProvidersContext();
   const [chainList, setChainList] = useState<Chain[]>();
   const [tokenList, setTokenList] = useState<Token[]>();
@@ -139,24 +140,28 @@ const BridgeForm: FC<BridgeFormProps> = ({ account, formData, resetForm, onSubmi
           .catch(resetBalanceAndNotifyError);
       } else {
         void getErc20TokenBalance({
-          token,
-          from: chains.from,
-          to: chains.to,
-          ethereumAddress: account,
+          chain: chains.from,
+          tokenAddress: token.address,
+          accountAddress: account,
         })
           .then(setBalanceFrom)
           .catch(resetBalanceAndNotifyError);
-        void getErc20TokenBalance({
+        void getWrappedTokenAddress({
           token,
-          from: chains.to,
-          to: chains.from,
-          ethereumAddress: account,
-        })
-          .then(setBalanceTo)
-          .catch(() => setBalanceTo(undefined));
+          from: chains.from,
+          to: chains.to,
+        }).then((tokenAddress) =>
+          getErc20TokenBalance({
+            chain: chains.to,
+            tokenAddress,
+            accountAddress: account,
+          })
+            .then(setBalanceTo)
+            .catch(() => setBalanceTo(undefined))
+        );
       }
     }
-  }, [chains, account, token, env, getErc20TokenBalance, notifyError]);
+  }, [chains, account, token, env, getErc20TokenBalance, notifyError, getWrappedTokenAddress]);
 
   useEffect(() => {
     if (chains && token) {

--- a/src/views/home/components/bridge-form/bridge-form.view.tsx
+++ b/src/views/home/components/bridge-form/bridge-form.view.tsx
@@ -148,8 +148,8 @@ const BridgeForm: FC<BridgeFormProps> = ({ account, formData, resetForm, onSubmi
           .catch(resetBalanceAndNotifyError);
         void getWrappedTokenAddress({
           token,
-          from: chains.from,
-          to: chains.to,
+          nativeTokenChain: chains.from,
+          wrappedTokenChain: chains.to,
         }).then((tokenAddress) =>
           getErc20TokenBalance({
             chain: chains.to,

--- a/src/views/home/components/token-list/token-list.view.tsx
+++ b/src/views/home/components/token-list/token-list.view.tsx
@@ -24,7 +24,10 @@ interface TokenListProps {
 const TokenList: FC<TokenListProps> = ({ tokens, selected, chain, onSelectToken, onClose }) => {
   const { getTokenFromAddress } = useBridgeContext();
   const classes = useListStyles();
-  const [filteredTokens, setFilteredTokens] = useState<Token[]>([...getCustomTokens(), ...tokens]);
+  const [filteredTokens, setFilteredTokens] = useState<Token[]>([
+    ...getCustomTokens().filter((token) => token.chainId === chain.chainId),
+    ...tokens,
+  ]);
   const [customToken, setCustomToken] = useState<AsyncTask<Token, string>>({ status: "pending" });
   const [searchInputValue, setSearchInputValue] = useState<string>("");
 


### PR DESCRIPTION
This PR changes the behavior of a [previous PR](https://github.com/hermeznetwork/bridge-ui/pull/85) by only listing the tokens that belong to the network selected in the `from` input.