### PR TITLE
Redirect to the log in page when a non-supported network is selected in MetaMask

### DIFF
--- a/src/contexts/providers.context.tsx
+++ b/src/contexts/providers.context.tsx
@@ -222,6 +222,12 @@ const ProvidersProvider: FC = (props) => {
   );
 
   useEffect(() => {
+    if (account.status === "failed") {
+      navigate(routes.login.path);
+    }
+  }, [account, navigate]);
+
+  useEffect(() => {
     const internalConnectedProvider: Record<string, unknown> | undefined =
       connectedProvider?.provider.provider;
     const onAccountsChanged = (accounts: unknown): void => {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -12,27 +12,27 @@ const routes = {
     isPrivate: true,
   },
   login: {
-    path: "/login",
+    path: "/login" as const,
     Component: Login,
     isPrivate: false,
   },
   settings: {
-    path: "/settings",
+    path: "/settings" as const,
     Component: Settings,
     isPrivate: true,
   },
   activity: {
-    path: "/activity",
+    path: "/activity" as const,
     Component: Activity,
     isPrivate: true,
   },
   bridgeDetails: {
-    path: "/bridge-details/:bridgeId",
+    path: "/bridge-details/:bridgeId" as const,
     Component: BridgeDetails,
     isPrivate: true,
   },
   bridgeConfirmation: {
-    path: "/bridge-confirmation",
+    path: "/bridge-confirmation" as const,
     Component: BridgeConfirmation,
     isPrivate: true,
   },


### PR DESCRIPTION
Closes #90

### What does this PR does?

This PR makes the application navigate to the login page whenever a non-supported network is selected in MetaMask.