### PR TITLE
Add pagination to the bridge list in Activity

### DIFF
--- a/src/adapters/bridge-api.ts
+++ b/src/adapters/bridge-api.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { StrictSchema } from "src/utils/type-safety";
 import * as domain from "src/domain";
+import { PAGE_SIZE } from "src/constants";
 
 interface DepositInput {
   token_addr: string;
@@ -118,17 +119,25 @@ const getMerkleProofResponseParser = StrictSchema<
 interface GetDepositsParams {
   apiUrl: string;
   ethereumAddress: string;
+  limit?: number;
+  offset?: number;
 }
 
 export const getDeposits = ({
   apiUrl,
   ethereumAddress,
+  limit = PAGE_SIZE,
+  offset = 0,
 }: GetDepositsParams): Promise<DepositOutput[]> => {
   return axios
     .request({
       baseURL: apiUrl,
       url: `/bridges/${ethereumAddress}`,
       method: "GET",
+      params: {
+        limit,
+        offset,
+      },
     })
     .then((res) => {
       const parsedData = getDepositsResponseParser.safeParse(res.data);

--- a/src/adapters/bridge-api.ts
+++ b/src/adapters/bridge-api.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { AxiosRequestConfig } from "axios";
 import { z } from "zod";
 
 import { StrictSchema } from "src/utils/type-safety";
@@ -121,6 +121,7 @@ interface GetDepositsParams {
   ethereumAddress: string;
   limit?: number;
   offset?: number;
+  cancelToken?: AxiosRequestConfig["cancelToken"];
 }
 
 export const getDeposits = ({
@@ -128,6 +129,7 @@ export const getDeposits = ({
   ethereumAddress,
   limit = PAGE_SIZE,
   offset = 0,
+  cancelToken,
 }: GetDepositsParams): Promise<DepositOutput[]> => {
   return axios
     .request({
@@ -138,6 +140,7 @@ export const getDeposits = ({
         limit,
         offset,
       },
+      cancelToken,
     })
     .then((res) => {
       const parsedData = getDepositsResponseParser.safeParse(res.data);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,6 +26,8 @@ export const SNACKBAR_AUTO_HIDE_DURATION = 5000;
 
 export const AUTO_REFRESH_RATE = 15000;
 
+export const PAGE_SIZE = 25;
+
 export const REPORT_ERROR_FORM_ENTRIES = {
   url: "entry.2056392454",
   network: "entry.1632331664",

--- a/src/contexts/bridge.context.tsx
+++ b/src/contexts/bridge.context.tsx
@@ -417,8 +417,8 @@ const BridgeProvider: FC = (props) => {
             .map((_, index) => {
               const offset = index * REFRESH_PAGE_SIZE;
               const isLast = index + 1 === requiredRequests;
-              const isReminderRequestRequired = isLast && remainderBridges !== 0;
-              const limit = isReminderRequestRequired ? remainderBridges : REFRESH_PAGE_SIZE;
+              const isRemainderRequestRequired = isLast && remainderBridges !== 0;
+              const limit = isRemainderRequestRequired ? remainderBridges : REFRESH_PAGE_SIZE;
               return getBridges({
                 env,
                 ethereumAddress,

--- a/src/contexts/bridge.context.tsx
+++ b/src/contexts/bridge.context.tsx
@@ -45,13 +45,13 @@ interface EstimateBridgeGasPriceParams {
   destinationAddress: string;
 }
 
-type GetBridgesParams = {
+interface GetBridgesParams {
   env: Env;
   ethereumAddress: string;
   limit: number;
   offset: number;
   cancelToken?: AxiosRequestConfig["cancelToken"];
-};
+}
 
 interface RefreshBridgesParams {
   env: Env;

--- a/src/contexts/bridge.context.tsx
+++ b/src/contexts/bridge.context.tsx
@@ -48,6 +48,8 @@ interface EstimateBridgeGasPriceParams {
 interface GetBridgesParams {
   env: Env;
   ethereumAddress: string;
+  limit: number;
+  offset: number;
 }
 
 interface ComputeWrappedTokenAddressParams {
@@ -225,9 +227,9 @@ const BridgeProvider: FC = (props) => {
   type TokenPrices = Partial<Record<string, Price>>;
 
   const getBridges = useCallback(
-    async ({ env, ethereumAddress }: GetBridgesParams): Promise<Bridge[]> => {
+    async ({ env, ethereumAddress, limit, offset }: GetBridgesParams): Promise<Bridge[]> => {
       const apiUrl = env.bridgeApiUrl;
-      const apiDeposits = await getDeposits({ apiUrl, ethereumAddress });
+      const apiDeposits = await getDeposits({ apiUrl, ethereumAddress, limit, offset });
 
       const deposits = await Promise.all(
         apiDeposits.map(async (apiDeposit): Promise<Deposit> => {

--- a/src/contexts/bridge.context.tsx
+++ b/src/contexts/bridge.context.tsx
@@ -56,7 +56,7 @@ interface GetBridgesParams {
 interface RefreshBridgesParams {
   env: Env;
   ethereumAddress: string;
-  bridges: Bridge[];
+  quantity: number;
 }
 
 type FetchBridgesParams = {
@@ -70,7 +70,7 @@ type FetchBridgesParams = {
     }
   | {
       type: "reload";
-      bridges: Bridge[];
+      quantity: number;
     }
 );
 
@@ -405,10 +405,10 @@ const BridgeProvider: FC = (props) => {
   const REFRESH_PAGE_SIZE = 100;
 
   const refreshBridges = useCallback(
-    async ({ env, ethereumAddress, bridges }: RefreshBridgesParams): Promise<Bridge[]> => {
+    async ({ env, ethereumAddress, quantity }: RefreshBridgesParams): Promise<Bridge[]> => {
       refreshCancelTokenSource.current = axios.CancelToken.source();
-      const completePages = Math.floor(bridges.length / REFRESH_PAGE_SIZE);
-      const remainderBridges = bridges.length % REFRESH_PAGE_SIZE;
+      const completePages = Math.floor(quantity / REFRESH_PAGE_SIZE);
+      const remainderBridges = quantity % REFRESH_PAGE_SIZE;
       const requiredRequests = remainderBridges === 0 ? completePages : completePages + 1;
       return (
         await Promise.all(
@@ -448,7 +448,7 @@ const BridgeProvider: FC = (props) => {
         return refreshBridges({
           env: params.env,
           ethereumAddress: params.ethereumAddress,
-          bridges: params.bridges,
+          quantity: params.quantity,
         });
       }
     },

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -85,7 +85,6 @@ export type Bridge =
       status: "completed";
       id: string;
       deposit: Deposit;
-      claim: Claim;
     };
 
 export interface Deposit {
@@ -97,11 +96,8 @@ export interface Deposit {
   tokenOriginNetwork: number;
   destinationAddress: string;
   depositCount: number;
-  txHash: string;
-}
-
-export interface Claim {
-  txHash: string;
+  depositTxHash: string;
+  claimTxHash: string | undefined;
 }
 
 export interface MerkleProof {

--- a/src/views/activity/activity.styles.ts
+++ b/src/views/activity/activity.styles.ts
@@ -59,6 +59,24 @@ const useActivityStyles = createUseStyles((theme: Theme) => ({
     padding: [theme.spacing(0.5), theme.spacing(1)],
     lineHeight: `${theme.spacing(1.75)}px`,
   },
+  loadMoreButtonWrapper: {
+    width: "100%",
+    textAlign: "center",
+    padding: theme.spacing(2),
+  },
+  loadMoreButton: {
+    border: "none",
+    padding: [theme.spacing(1), theme.spacing(3)],
+    borderRadius: 32,
+    backgroundColor: theme.palette.primary.main,
+    color: theme.palette.white,
+    fontWeight: 700,
+    lineHeight: "20px",
+    cursor: "pointer",
+    "&:hover": {
+      backgroundColor: theme.palette.primary.dark,
+    },
+  },
 }));
 
 export default useActivityStyles;

--- a/src/views/activity/activity.styles.ts
+++ b/src/views/activity/activity.styles.ts
@@ -59,24 +59,6 @@ const useActivityStyles = createUseStyles((theme: Theme) => ({
     padding: [theme.spacing(0.5), theme.spacing(1)],
     lineHeight: `${theme.spacing(1.75)}px`,
   },
-  loadMoreButtonWrapper: {
-    width: "100%",
-    textAlign: "center",
-    padding: theme.spacing(2),
-  },
-  loadMoreButton: {
-    border: "none",
-    padding: [theme.spacing(1), theme.spacing(3)],
-    borderRadius: 32,
-    backgroundColor: theme.palette.primary.main,
-    color: theme.palette.white,
-    fontWeight: 700,
-    lineHeight: "20px",
-    cursor: "pointer",
-    "&:hover": {
-      backgroundColor: theme.palette.primary.dark,
-    },
-  },
 }));
 
 export default useActivityStyles;

--- a/src/views/activity/activity.view.tsx
+++ b/src/views/activity/activity.view.tsx
@@ -25,7 +25,6 @@ const Activity: FC = () => {
   const { notifyError } = useErrorContext();
   const [bridgeList, setBridgeList] = useState<AsyncTask<Bridge[], string>>({ status: "pending" });
   const [displayAll, setDisplayAll] = useState(true);
-  const [nextFromItem, setNextFromItem] = useState(PAGE_SIZE);
   const [endReached, setEndReached] = useState(false);
   const [wrongNetworkBridges, setWrongNetworkBridges] = useState<Bridge["id"][]>([]);
   const classes = useActivityStyles({ displayAll });
@@ -87,7 +86,6 @@ const Activity: FC = () => {
       endReached === false
     ) {
       setBridgeList({ status: "reloading", data: bridgeList.data });
-      setNextFromItem(fromItem + PAGE_SIZE);
       fetchBridges({
         type: "load",
         env,
@@ -202,7 +200,7 @@ const Activity: FC = () => {
             </div>
             <InfiniteScroll
               asyncTaskStatus={bridgeList.status}
-              fromItem={nextFromItem}
+              fromItem={bridgeList.data.length}
               onLoadNextPage={loadNextPage}
             >
               {filteredList.map((bridge) => (

--- a/src/views/activity/activity.view.tsx
+++ b/src/views/activity/activity.view.tsx
@@ -219,7 +219,7 @@ const Activity: FC = () => {
                 <button
                   className={classes.loadMoreButton}
                   onClick={() => {
-                    loadNextPage(bridgeList.data.length + PAGE_SIZE);
+                    loadNextPage(bridgeList.data.length);
                   }}
                 >
                   Load More

--- a/src/views/activity/activity.view.tsx
+++ b/src/views/activity/activity.view.tsx
@@ -97,18 +97,16 @@ const Activity: FC = () => {
   }, [account, env, fetchBridges, processFetchBridgesError, processFetchBridgesSuccess]);
 
   useEffect(() => {
-    if (env && account.status === "successful") {
+    if (env && account.status === "successful" && bridgeList.status === "successful") {
       const refreshBridges = () => {
-        if (bridgeList.status === "successful") {
-          fetchBridges({
-            type: "reload",
-            env,
-            ethereumAddress: account.data,
-            bridges: bridgeList.data,
-          })
-            .then(processFetchBridgesSuccess)
-            .catch(processFetchBridgesError);
-        }
+        fetchBridges({
+          type: "reload",
+          env,
+          ethereumAddress: account.data,
+          bridges: bridgeList.data,
+        })
+          .then(processFetchBridgesSuccess)
+          .catch(processFetchBridgesError);
       };
       const intervalId = setInterval(refreshBridges, AUTO_REFRESH_RATE);
 

--- a/src/views/activity/activity.view.tsx
+++ b/src/views/activity/activity.view.tsx
@@ -1,5 +1,6 @@
 import { useState, FC, useEffect } from "react";
 
+import InfiniteScroll from "src/views/activity/components/infinite-scroll/infinite-scroll.view";
 import BridgeCard from "src/views/activity/components/bridge-card/bridge-card.view";
 import useActivityStyles from "src/views/activity/activity.styles";
 import Typography from "src/views/shared/typography/typography.view";
@@ -24,6 +25,8 @@ const Activity: FC = () => {
   const { notifyError } = useErrorContext();
   const [bridgeList, setBridgeList] = useState<AsyncTask<Bridge[], string>>({ status: "pending" });
   const [displayAll, setDisplayAll] = useState(true);
+  const [nextFromItem, setNextFromItem] = useState(PAGE_SIZE);
+  const [endReached, setEndReached] = useState(false);
   const [wrongNetworkBridges, setWrongNetworkBridges] = useState<Bridge["id"][]>([]);
   const classes = useActivityStyles({ displayAll });
 
@@ -73,77 +76,119 @@ const Activity: FC = () => {
             });
           });
       };
-      const intervalId = setInterval(loadBridges, AUTO_REFRESH_RATE);
+      // const intervalId = setInterval(loadBridges, AUTO_REFRESH_RATE);
       loadBridges();
 
-      return () => {
-        clearInterval(intervalId);
-      };
+      // return () => {
+      //   clearInterval(intervalId);
+      // };
     }
   }, [account, env, getBridges, notifyError, callIfMounted]);
 
   useEffect(() => {
     setWrongNetworkBridges([]);
   }, [connectedProvider?.chainId]);
-  switch (bridgeList.status) {
-    case "pending":
-    case "loading":
-    case "reloading": {
-      return (
-        <>
-          <Header title="Activity" backTo="home" />
-          <PageLoader />
-        </>
-      );
-    }
-    case "failed": {
-      return (
-        <>
-          <Header title="Activity" backTo="home" />
-          <Error error={bridgeList.error} />
-        </>
-      );
-    }
-    case "successful": {
-      const pendingBridges = bridgeList.data.filter((bridge) => bridge.status !== "completed");
-      const filteredList = displayAll ? bridgeList.data : pendingBridges;
 
-      return (
-        <>
-          <Header title="Activity" backTo="home" />
-          <div className={classes.selectorBoxes}>
-            <div className={`${classes.selectorBox} ${classes.allBox}`} onClick={onDisplayAll}>
-              <Typography type="body1" className={classes.status}>
-                All
-              </Typography>
-              <Typography type="body2" className={classes.numberAllBox}>
-                {bridgeList.data.length}
-              </Typography>
-            </div>
-            <div
-              className={`${classes.selectorBox} ${classes.pendingBox}`}
-              onClick={onDisplayPending}
-            >
-              <Typography type="body1" className={classes.status}>
-                Pending
-              </Typography>
-              <Typography type="body2" className={classes.numberPendingBox}>
-                {pendingBridges.length}
-              </Typography>
-            </div>
-          </div>
-          {filteredList.map((bridge) => (
-            <BridgeCard
-              bridge={bridge}
-              onClaim={() => onClaim(bridge)}
-              networkError={wrongNetworkBridges.includes(bridge.id)}
-              key={bridge.id}
-            />
-          ))}
-        </>
-      );
-    }
-  }
+  return (
+    <InfiniteScroll
+      asyncTaskStatus={bridgeList.status}
+      fromItem={nextFromItem}
+      onLoadNextPage={(fromItem) => {
+        if (
+          env &&
+          account.status === "successful" &&
+          bridgeList.status === "successful" &&
+          endReached === false
+        ) {
+          setBridgeList({ status: "reloading", data: bridgeList.data });
+          setNextFromItem(fromItem + PAGE_SIZE);
+          getBridges({ env, ethereumAddress: account.data, limit: PAGE_SIZE, offset: fromItem })
+            .then((bridges) => {
+              callIfMounted(() => {
+                setEndReached(bridges.length < PAGE_SIZE);
+                setBridgeList({ status: "successful", data: [...bridgeList.data, ...bridges] });
+              });
+            })
+            .catch((error) => {
+              callIfMounted(() => {
+                setBridgeList({
+                  status: "failed",
+                  error: "Something is wrong, we couldn't load the Bridges",
+                });
+                notifyError(error);
+              });
+            });
+        }
+      }}
+    >
+      {(() => {
+        switch (bridgeList.status) {
+          case "pending":
+          case "loading": {
+            return (
+              <>
+                <Header title="Activity" backTo="home" />
+                <PageLoader />
+              </>
+            );
+          }
+          case "failed": {
+            return (
+              <>
+                <Header title="Activity" backTo="home" />
+                <Error error={bridgeList.error} />
+              </>
+            );
+          }
+          case "successful":
+          case "reloading": {
+            const pendingBridges = bridgeList.data.filter(
+              (bridge) => bridge.status !== "completed"
+            );
+            const filteredList = displayAll ? bridgeList.data : pendingBridges;
+
+            return (
+              <>
+                <Header title="Activity" backTo="home" />
+                <div className={classes.selectorBoxes}>
+                  <div
+                    className={`${classes.selectorBox} ${classes.allBox}`}
+                    onClick={onDisplayAll}
+                  >
+                    <Typography type="body1" className={classes.status}>
+                      All
+                    </Typography>
+                    <Typography type="body2" className={classes.numberAllBox}>
+                      {bridgeList.data.length}
+                    </Typography>
+                  </div>
+                  <div
+                    className={`${classes.selectorBox} ${classes.pendingBox}`}
+                    onClick={onDisplayPending}
+                  >
+                    <Typography type="body1" className={classes.status}>
+                      Pending
+                    </Typography>
+                    <Typography type="body2" className={classes.numberPendingBox}>
+                      {pendingBridges.length}
+                    </Typography>
+                  </div>
+                </div>
+                {filteredList.map((bridge) => (
+                  <BridgeCard
+                    bridge={bridge}
+                    onClaim={() => onClaim(bridge)}
+                    networkError={wrongNetworkBridges.includes(bridge.id)}
+                    key={bridge.id}
+                  />
+                ))}
+              </>
+            );
+          }
+        }
+      })()}
+    </InfiniteScroll>
+  );
 };
 
 export default Activity;

--- a/src/views/activity/activity.view.tsx
+++ b/src/views/activity/activity.view.tsx
@@ -58,6 +58,29 @@ const Activity: FC = () => {
     }
   };
 
+  const processFetchBridgesSuccess = useCallback(
+    (bridges: Bridge[]) => {
+      callIfMounted(() => {
+        setLastLoadedItem(bridges.length);
+        setBridgeList({ status: "successful", data: bridges });
+      });
+    },
+    [callIfMounted]
+  );
+
+  const processFetchBridgesError = useCallback(
+    (error: unknown) => {
+      callIfMounted(() => {
+        setBridgeList({
+          status: "failed",
+          error: undefined,
+        });
+        notifyError(error);
+      });
+    },
+    [callIfMounted, notifyError]
+  );
+
   const onLoadNextPage = () => {
     if (
       env &&
@@ -83,29 +106,6 @@ const Activity: FC = () => {
     }
   };
 
-  const processFetchBridgesSuccess = useCallback(
-    (bridges: Bridge[]) => {
-      callIfMounted(() => {
-        setLastLoadedItem(bridges.length);
-        setBridgeList({ status: "successful", data: bridges });
-      });
-    },
-    [callIfMounted]
-  );
-
-  const processFetchBridgesError = useCallback(
-    (error: unknown) => {
-      callIfMounted(() => {
-        setBridgeList({
-          status: "failed",
-          error: undefined,
-        });
-        notifyError(error);
-      });
-    },
-    [callIfMounted, notifyError]
-  );
-
   useEffect(() => {
     if (env && account.status === "successful") {
       const loadBridges = () => {
@@ -116,12 +116,24 @@ const Activity: FC = () => {
           limit: PAGE_SIZE,
           offset: 0,
         })
-          .then(processFetchBridgesSuccess)
+          .then((bridges) => {
+            callIfMounted(() => {
+              processFetchBridgesSuccess(bridges);
+              setEndReached(bridges.length < PAGE_SIZE);
+            });
+          })
           .catch(processFetchBridgesError);
       };
       loadBridges();
     }
-  }, [account, env, fetchBridges, processFetchBridgesError, processFetchBridgesSuccess]);
+  }, [
+    account,
+    env,
+    callIfMounted,
+    fetchBridges,
+    processFetchBridgesError,
+    processFetchBridgesSuccess,
+  ]);
 
   useEffect(() => {
     if (
@@ -141,7 +153,12 @@ const Activity: FC = () => {
           ethereumAddress: account.data,
           quantity: lastLoadedItem,
         })
-          .then(processFetchBridgesSuccess)
+          .then((bridges) => {
+            callIfMounted(() => {
+              processFetchBridgesSuccess(bridges);
+              setEndReached(bridges.length < PAGE_SIZE);
+            });
+          })
           .catch(processFetchBridgesError);
       };
       const intervalId = setInterval(refreshBridges, AUTO_REFRESH_RATE);
@@ -158,6 +175,7 @@ const Activity: FC = () => {
     fetchBridges,
     processFetchBridgesError,
     processFetchBridgesSuccess,
+    callIfMounted,
   ]);
 
   useEffect(() => {

--- a/src/views/activity/activity.view.tsx
+++ b/src/views/activity/activity.view.tsx
@@ -12,7 +12,7 @@ import { useEnvContext } from "src/contexts/env.context";
 import { useErrorContext } from "src/contexts/error.context";
 import { parseError } from "src/adapters/error";
 import { AsyncTask, isMetamaskUserRejectedRequestError } from "src/utils/types";
-import { AUTO_REFRESH_RATE } from "src/constants";
+import { AUTO_REFRESH_RATE, PAGE_SIZE } from "src/constants";
 import { Bridge } from "src/domain";
 import useCallIfMounted from "src/hooks/use-call-if-mounted";
 
@@ -57,7 +57,7 @@ const Activity: FC = () => {
   useEffect(() => {
     if (env && account.status === "successful") {
       const loadBridges = () => {
-        getBridges({ env, ethereumAddress: account.data })
+        getBridges({ env, ethereumAddress: account.data, limit: PAGE_SIZE, offset: 0 })
           .then((bridges) => {
             callIfMounted(() => {
               setBridgeList({ status: "successful", data: bridges });

--- a/src/views/activity/activity.view.tsx
+++ b/src/views/activity/activity.view.tsx
@@ -123,6 +123,7 @@ const Activity: FC = () => {
   useEffect(() => {
     if (env && account.status === "successful" && bridgeList.status === "successful") {
       const refreshBridges = () => {
+        setBridgeList({ status: "reloading", data: bridgeList.data });
         fetchBridges({
           type: "reload",
           env,
@@ -201,6 +202,7 @@ const Activity: FC = () => {
             <InfiniteScroll
               asyncTaskStatus={bridgeList.status}
               fromItem={bridgeList.data.length}
+              endReached={endReached}
               onLoadNextPage={loadNextPage}
             >
               {filteredList.map((bridge) => (
@@ -212,18 +214,6 @@ const Activity: FC = () => {
                 />
               ))}
             </InfiniteScroll>
-            {endReached === false && bridgeList.status === "successful" && (
-              <div className={classes.loadMoreButtonWrapper}>
-                <button
-                  className={classes.loadMoreButton}
-                  onClick={() => {
-                    loadNextPage(bridgeList.data.length);
-                  }}
-                >
-                  Load More
-                </button>
-              </div>
-            )}
           </>
         );
       }

--- a/src/views/activity/components/infinite-scroll/infinite-scroll.styles.ts
+++ b/src/views/activity/components/infinite-scroll/infinite-scroll.styles.ts
@@ -1,0 +1,18 @@
+import { createUseStyles } from "react-jss";
+
+import { Theme } from "src/styles/theme";
+
+const useInfiniteScrollStyles = createUseStyles((theme: Theme) => ({
+  root: {
+    width: "100%",
+  },
+  spinnerWrapper: {
+    width: "100%",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    paddingTop: theme.spacing(3),
+  },
+}));
+
+export default useInfiniteScrollStyles;

--- a/src/views/activity/components/infinite-scroll/infinite-scroll.styles.ts
+++ b/src/views/activity/components/infinite-scroll/infinite-scroll.styles.ts
@@ -13,6 +13,31 @@ const useInfiniteScrollStyles = createUseStyles((theme: Theme) => ({
     justifyContent: "center",
     paddingTop: theme.spacing(3),
   },
+  loadMoreButtonWrapper: {
+    width: "100%",
+    padding: theme.spacing(2),
+  },
+  loadMoreButton: {
+    margin: "auto",
+    display: "flex",
+    justifyContent: "center",
+    minWidth: 150,
+    border: "none",
+    padding: [theme.spacing(0.75), theme.spacing(3)],
+    borderRadius: 32,
+    backgroundColor: theme.palette.primary.main,
+    color: theme.palette.white,
+    fontWeight: 700,
+    lineHeight: "20px",
+    cursor: "pointer",
+    "&:hover": {
+      backgroundColor: theme.palette.primary.dark,
+    },
+    "&:disabled": {
+      backgroundColor: theme.palette.disabled,
+      cursor: "initial",
+    },
+  },
 }));
 
 export default useInfiniteScrollStyles;

--- a/src/views/activity/components/infinite-scroll/infinite-scroll.view.tsx
+++ b/src/views/activity/components/infinite-scroll/infinite-scroll.view.tsx
@@ -8,14 +8,12 @@ const TRESHOLD = 0.9;
 
 interface InfiniteScrollProps {
   asyncTaskStatus: AsyncTask<never, never>["status"];
-  onLoadNextPage: (offset: number) => void;
-  fromItem: number;
+  onLoadNextPage: () => void;
   endReached: boolean;
 }
 
 const InfiniteScroll: React.FC<InfiniteScrollProps> = ({
   asyncTaskStatus,
-  fromItem,
   endReached,
   children,
   onLoadNextPage,
@@ -43,10 +41,10 @@ const InfiniteScroll: React.FC<InfiniteScrollProps> = ({
 
   React.useEffect(() => {
     if (scrollReachedEnd && asyncTaskStatus === "successful") {
-      onLoadNextPage(fromItem);
+      onLoadNextPage();
     }
     setScrollReachedEnd(false);
-  }, [fromItem, asyncTaskStatus, scrollReachedEnd, onLoadNextPage]);
+  }, [asyncTaskStatus, scrollReachedEnd, onLoadNextPage]);
 
   return (
     <div className={classes.root} ref={ref}>
@@ -60,9 +58,7 @@ const InfiniteScroll: React.FC<InfiniteScrollProps> = ({
         <div className={classes.loadMoreButtonWrapper}>
           <button
             className={classes.loadMoreButton}
-            onClick={() => {
-              onLoadNextPage(fromItem);
-            }}
+            onClick={onLoadNextPage}
             disabled={asyncTaskStatus === "reloading"}
           >
             {asyncTaskStatus === "reloading" ? <Spinner size={20} color="white" /> : "Load More"}

--- a/src/views/activity/components/infinite-scroll/infinite-scroll.view.tsx
+++ b/src/views/activity/components/infinite-scroll/infinite-scroll.view.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+
+import Spinner from "src/views/shared/spinner/spinner.view";
+import useInfiniteScrollStyles from "src/views/activity/components/infinite-scroll/infinite-scroll.styles";
+import { AsyncTask } from "src/utils/types";
+
+const TRESHOLD = 0.9;
+
+interface InfiniteScrollProps {
+  asyncTaskStatus: AsyncTask<never, never>["status"];
+  onLoadNextPage: (offset: number) => void;
+  fromItem: number;
+}
+
+const InfiniteScroll: React.FC<InfiniteScrollProps> = ({
+  asyncTaskStatus,
+  fromItem,
+  children,
+  onLoadNextPage,
+}) => {
+  const classes = useInfiniteScrollStyles();
+  const [scrollReachedEnd, setScrollReachedEnd] = React.useState(false);
+  const ref = React.useRef<HTMLDivElement | null>(null);
+
+  React.useEffect(() => {
+    const onScroll = () => {
+      if (
+        ref.current &&
+        ref.current.getBoundingClientRect().bottom * TRESHOLD <= window.innerHeight
+      ) {
+        setScrollReachedEnd(true);
+      }
+    };
+
+    if (ref.current !== null) {
+      document.addEventListener("scroll", onScroll);
+
+      return () => document.removeEventListener("scroll", onScroll);
+    }
+  }, [ref]);
+
+  React.useEffect(() => {
+    if (scrollReachedEnd && asyncTaskStatus === "successful") {
+      onLoadNextPage(fromItem);
+    }
+    setScrollReachedEnd(false);
+  }, [fromItem, asyncTaskStatus, scrollReachedEnd, onLoadNextPage]);
+
+  return (
+    <div className={classes.root} ref={ref}>
+      {children}
+      {(asyncTaskStatus === "loading" || asyncTaskStatus === "reloading") && (
+        <div className={classes.spinnerWrapper}>
+          <Spinner size={24} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default InfiniteScroll;

--- a/src/views/activity/components/infinite-scroll/infinite-scroll.view.tsx
+++ b/src/views/activity/components/infinite-scroll/infinite-scroll.view.tsx
@@ -10,11 +10,13 @@ interface InfiniteScrollProps {
   asyncTaskStatus: AsyncTask<never, never>["status"];
   onLoadNextPage: (offset: number) => void;
   fromItem: number;
+  endReached: boolean;
 }
 
 const InfiniteScroll: React.FC<InfiniteScrollProps> = ({
   asyncTaskStatus,
   fromItem,
+  endReached,
   children,
   onLoadNextPage,
 }) => {
@@ -49,9 +51,22 @@ const InfiniteScroll: React.FC<InfiniteScrollProps> = ({
   return (
     <div className={classes.root} ref={ref}>
       {children}
-      {(asyncTaskStatus === "loading" || asyncTaskStatus === "reloading") && (
+      {endReached && asyncTaskStatus === "reloading" && (
         <div className={classes.spinnerWrapper}>
           <Spinner size={24} />
+        </div>
+      )}
+      {endReached === false && (
+        <div className={classes.loadMoreButtonWrapper}>
+          <button
+            className={classes.loadMoreButton}
+            onClick={() => {
+              onLoadNextPage(fromItem);
+            }}
+            disabled={asyncTaskStatus === "reloading"}
+          >
+            {asyncTaskStatus === "reloading" ? <Spinner size={20} color="white" /> : "Load More"}
+          </button>
         </div>
       )}
     </div>

--- a/src/views/bridge-details/bridge-details.view.tsx
+++ b/src/views/bridge-details/bridge-details.view.tsx
@@ -25,7 +25,7 @@ import { formatTokenAmount, formatFiatAmount, multiplyAmounts } from "src/utils/
 import { calculateTransactionResponseFee } from "src/utils/fees";
 import { Bridge } from "src/domain";
 import routes from "src/routes";
-import { getChainTokens, FIAT_DISPLAY_PRECISION } from "src/constants";
+import { getChainTokens, FIAT_DISPLAY_PRECISION, PAGE_SIZE } from "src/constants";
 import useCallIfMounted from "src/hooks/use-call-if-mounted";
 
 interface Fees {
@@ -112,7 +112,7 @@ const BridgeDetails: FC = () => {
   useEffect(() => {
     if (env && account.status === "successful") {
       // ToDo: Get all the data only for the right bridge
-      void getBridges({ env, ethereumAddress: account.data })
+      void getBridges({ env, ethereumAddress: account.data, limit: PAGE_SIZE, offset: 0 })
         .then((bridges) => {
           const foundBridge = bridges.find((bridge) => {
             return bridge.id === bridgeId;

--- a/src/views/bridge-details/bridge-details.view.tsx
+++ b/src/views/bridge-details/bridge-details.view.tsx
@@ -35,13 +35,13 @@ interface Fees {
 
 const calculateFees = (bridge: Bridge): Promise<Fees> => {
   const step1Promise = bridge.deposit.from.provider
-    .getTransaction(bridge.deposit.txHash)
+    .getTransaction(bridge.deposit.depositTxHash)
     .then(calculateTransactionResponseFee);
 
   const step2Promise =
-    bridge.status === "completed"
+    bridge.deposit.claimTxHash !== undefined
       ? bridge.deposit.to.provider
-          .getTransaction(bridge.claim.txHash)
+          .getTransaction(bridge.deposit.claimTxHash)
           .then(calculateTransactionResponseFee)
       : Promise.resolve(undefined);
 
@@ -254,14 +254,12 @@ const BridgeDetails: FC = () => {
     case "successful": {
       const {
         status,
-        deposit: { amount, from, to, token, txHash },
+        deposit: { amount, from, to, token, depositTxHash, claimTxHash },
       } = bridge.data;
 
-      const bridgeTxUrl = `${from.explorerUrl}/tx/${txHash}`;
+      const bridgeTxUrl = `${from.explorerUrl}/tx/${depositTxHash}`;
       const claimTxUrl =
-        bridge.data.status === "completed"
-          ? `${to.explorerUrl}/tx/${bridge.data.claim.txHash}`
-          : undefined;
+        claimTxHash !== undefined ? `${to.explorerUrl}/tx/${claimTxHash}` : undefined;
 
       const { step1: step1EthFee, step2: step2EthFee } = ethFees;
       const { step1: step1FiatFee, step2: step2FiatFee } = fiatFees;

--- a/src/views/bridge-details/bridge-details.view.tsx
+++ b/src/views/bridge-details/bridge-details.view.tsx
@@ -25,7 +25,7 @@ import { formatTokenAmount, formatFiatAmount, multiplyAmounts } from "src/utils/
 import { calculateTransactionResponseFee } from "src/utils/fees";
 import { Bridge } from "src/domain";
 import routes from "src/routes";
-import { getChainTokens, FIAT_DISPLAY_PRECISION, PAGE_SIZE } from "src/constants";
+import { getChainTokens, FIAT_DISPLAY_PRECISION } from "src/constants";
 import useCallIfMounted from "src/hooks/use-call-if-mounted";
 
 interface Fees {
@@ -57,7 +57,7 @@ const BridgeDetails: FC = () => {
   const navigate = useNavigate();
   const env = useEnvContext();
   const { notifyError } = useErrorContext();
-  const { getBridges, claim } = useBridgeContext();
+  const { fetchBridges, claim } = useBridgeContext();
   const { account, connectedProvider } = useProvidersContext();
   const { getTokenPrice } = usePriceOracleContext();
   const [incorrectNetworkMessage, setIncorrectNetworkMessage] = useState<string>();
@@ -112,7 +112,13 @@ const BridgeDetails: FC = () => {
   useEffect(() => {
     if (env && account.status === "successful") {
       // ToDo: Get all the data only for the right bridge
-      void getBridges({ env, ethereumAddress: account.data, limit: PAGE_SIZE, offset: 0 })
+      void fetchBridges({
+        type: "load",
+        env,
+        ethereumAddress: account.data,
+        limit: 100,
+        offset: 0,
+      })
         .then((bridges) => {
           const foundBridge = bridges.find((bridge) => {
             return bridge.id === bridgeId;
@@ -135,7 +141,7 @@ const BridgeDetails: FC = () => {
         })
         .catch(notifyError);
     }
-  }, [account, env, bridgeId, notifyError, getBridges, callIfMounted]);
+  }, [account, env, bridgeId, notifyError, fetchBridges, callIfMounted]);
 
   useEffect(() => {
     if (bridge.status === "successful") {

--- a/src/views/shared/spinner/spinner.styles.ts
+++ b/src/views/shared/spinner/spinner.styles.ts
@@ -4,6 +4,7 @@ import { Theme } from "src/styles/theme";
 
 interface StyleProps {
   size: number;
+  color?: string;
 }
 
 const useSpinnerStyles = createUseStyles((theme: Theme) => ({
@@ -19,16 +20,18 @@ const useSpinnerStyles = createUseStyles((theme: Theme) => ({
   svg: {
     animation: "$spin 0.8s linear infinite",
   },
-  topCircle: {
-    stroke: theme.palette.primary.main,
+  topCircle: ({ color = theme.palette.primary.main }: StyleProps) => ({
+    stroke: color,
     strokeLinecap: "round",
     strokeDasharray: "30px 200px",
     strokeDashoffset: "0px",
-  },
-  bottomCircle: {
-    stroke: theme.palette.primary.main,
-    strokeOpacity: 0.2,
-  },
+  }),
+  bottomCircle: ({ color = theme.palette.primary.main }: StyleProps) => ({
+    bottomCircle: {
+      stroke: color,
+      strokeOpacity: 0.2,
+    },
+  }),
 }));
 
 export default useSpinnerStyles;

--- a/src/views/shared/spinner/spinner.view.tsx
+++ b/src/views/shared/spinner/spinner.view.tsx
@@ -5,10 +5,11 @@ const THICKNESS = 3;
 
 interface SpinnerProps {
   size?: number;
+  color?: string;
 }
 
-function Spinner({ size }: SpinnerProps): JSX.Element {
-  const classes = useSpinnerStyles({ size: size !== undefined ? size : 48 });
+function Spinner({ size, color }: SpinnerProps): JSX.Element {
+  const classes = useSpinnerStyles({ size: size !== undefined ? size : 48, color });
 
   return (
     <div className={classes.root}>


### PR DESCRIPTION
Closes #104

### What does this PR does?

This PR implements the new pagination API of the bridge's service.

Initially, only the first 25 elements are loaded and from there, more batches/pages are loaded as required when the user scrolls to the bottom of the page or uses the "Load more" button.

The polling has been refactored to exactly reload the number of bridges visible, if required with several requests, in batches of 100 items.