### PR TITLE
Improve the pagination

### DIFF
--- a/src/adapters/bridge-api.ts
+++ b/src/adapters/bridge-api.ts
@@ -216,7 +216,7 @@ export const getMerkleProof = ({
   return axios
     .request({
       baseURL: apiUrl,
-      url: `/merkle-proofs`,
+      url: `/merkle-proof`,
       method: "GET",
       params: {
         net_id: networkId,

--- a/src/contexts/bridge.context.tsx
+++ b/src/contexts/bridge.context.tsx
@@ -520,22 +520,6 @@ const BridgeProvider: FC = (props) => {
         });
 
         switch (claim.status) {
-          case "claimed": {
-            return {
-              status: "completed",
-              id,
-              token,
-              amount,
-              destinationAddress,
-              depositCount,
-              depositTxHash,
-              from,
-              to,
-              tokenOriginNetwork,
-              claimTxHash: claim.txHash,
-              fiatAmount,
-            };
-          }
           case "pending": {
             return {
               status: "initiated",
@@ -563,6 +547,22 @@ const BridgeProvider: FC = (props) => {
               from,
               to,
               tokenOriginNetwork,
+              fiatAmount,
+            };
+          }
+          case "claimed": {
+            return {
+              status: "completed",
+              id,
+              token,
+              amount,
+              destinationAddress,
+              depositCount,
+              depositTxHash,
+              from,
+              to,
+              tokenOriginNetwork,
+              claimTxHash: claim.txHash,
               fiatAmount,
             };
           }

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -90,7 +90,6 @@ export type InitiatedBridge = BridgeCommonFields & {
 
 export type OnHoldBridge = BridgeCommonFields & {
   status: "on-hold";
-  merkleProof: MerkleProof;
 };
 
 export type CompletedBridge = BridgeCommonFields & {

--- a/src/views/activity/activity.view.tsx
+++ b/src/views/activity/activity.view.tsx
@@ -102,9 +102,8 @@ const Activity: FC = () => {
         ethereumAddress: account.data,
         quantity: lastLoadedItem + PAGE_SIZE,
       })
-        .then((response) => {
+        .then(({ bridges, total }) => {
           callIfMounted(() => {
-            const { bridges, total } = response;
             processFetchBridgesSuccess(bridges);
             setTotal(total);
           });
@@ -123,9 +122,8 @@ const Activity: FC = () => {
           limit: PAGE_SIZE,
           offset: 0,
         })
-          .then((response) => {
+          .then(({ bridges, total }) => {
             callIfMounted(() => {
-              const { bridges, total } = response;
               processFetchBridgesSuccess(bridges);
               setTotal(total);
             });
@@ -161,9 +159,8 @@ const Activity: FC = () => {
           ethereumAddress: account.data,
           quantity: lastLoadedItem,
         })
-          .then((response) => {
+          .then(({ bridges, total }) => {
             callIfMounted(() => {
-              const { bridges, total } = response;
               processFetchBridgesSuccess(bridges);
               setTotal(total);
             });

--- a/src/views/activity/activity.view.tsx
+++ b/src/views/activity/activity.view.tsx
@@ -97,18 +97,16 @@ const Activity: FC = () => {
     ) {
       setBridgeList({ status: "reloading", data: bridgeList.data });
       fetchBridges({
-        type: "load",
+        type: "reload",
         env,
         ethereumAddress: account.data,
-        limit: PAGE_SIZE,
-        offset: lastLoadedItem,
+        quantity: lastLoadedItem + PAGE_SIZE,
       })
         .then((response) => {
           callIfMounted(() => {
             const { bridges, total } = response;
-            const mergedBridges = [...bridgeList.data, ...bridges];
-            processFetchBridgesSuccess(mergedBridges);
-            setEndReached(mergedBridges.length === total);
+            processFetchBridgesSuccess(bridges);
+            setEndReached(bridges.length === total);
           });
         })
         .catch(processFetchBridgesError);

--- a/src/views/activity/activity.view.tsx
+++ b/src/views/activity/activity.view.tsx
@@ -242,8 +242,7 @@ const Activity: FC = () => {
             </div>
             {filteredList.length ? (
               <InfiniteScroll
-                asyncTaskStatus={bridgeList.status}
-                endReached={bridgeList.data.length === total}
+                isLoading={bridgeList.status === "reloading"}
                 onLoadNextPage={onLoadNextPage}
               >
                 {filteredList.map((bridge) => (

--- a/src/views/activity/activity.view.tsx
+++ b/src/views/activity/activity.view.tsx
@@ -29,7 +29,7 @@ const Activity: FC = () => {
   });
   const [displayAll, setDisplayAll] = useState(true);
   const [lastLoadedItem, setLastLoadedItem] = useState(0);
-  const [endReached, setEndReached] = useState(false);
+  const [total, setTotal] = useState(0);
   const [wrongNetworkBridges, setWrongNetworkBridges] = useState<Bridge["id"][]>([]);
   const classes = useActivityStyles({ displayAll });
 
@@ -93,7 +93,7 @@ const Activity: FC = () => {
       env &&
       account.status === "successful" &&
       bridgeList.status === "successful" &&
-      endReached === false
+      bridgeList.data.length < total
     ) {
       setBridgeList({ status: "reloading", data: bridgeList.data });
       fetchBridges({
@@ -106,7 +106,7 @@ const Activity: FC = () => {
           callIfMounted(() => {
             const { bridges, total } = response;
             processFetchBridgesSuccess(bridges);
-            setEndReached(bridges.length === total);
+            setTotal(total);
           });
         })
         .catch(processFetchBridgesError);
@@ -127,7 +127,7 @@ const Activity: FC = () => {
             callIfMounted(() => {
               const { bridges, total } = response;
               processFetchBridgesSuccess(bridges);
-              setEndReached(bridges.length === total);
+              setTotal(total);
             });
           })
           .catch(processFetchBridgesError);
@@ -165,7 +165,7 @@ const Activity: FC = () => {
             callIfMounted(() => {
               const { bridges, total } = response;
               processFetchBridgesSuccess(bridges);
-              setEndReached(bridges.length === total);
+              setTotal(total);
             });
           })
           .catch(processFetchBridgesError);
@@ -243,7 +243,7 @@ const Activity: FC = () => {
             {filteredList.length ? (
               <InfiniteScroll
                 asyncTaskStatus={bridgeList.status}
-                endReached={endReached}
+                endReached={bridgeList.data.length === total}
                 onLoadNextPage={onLoadNextPage}
               >
                 {filteredList.map((bridge) => (

--- a/src/views/activity/activity.view.tsx
+++ b/src/views/activity/activity.view.tsx
@@ -103,10 +103,12 @@ const Activity: FC = () => {
         limit: PAGE_SIZE,
         offset: lastLoadedItem,
       })
-        .then((bridges) => {
+        .then((response) => {
           callIfMounted(() => {
-            processFetchBridgesSuccess([...bridgeList.data, ...bridges]);
-            setEndReached(bridges.length < PAGE_SIZE);
+            const { bridges, total } = response;
+            const mergedBridges = [...bridgeList.data, ...bridges];
+            processFetchBridgesSuccess(mergedBridges);
+            setEndReached(mergedBridges.length === total);
           });
         })
         .catch(processFetchBridgesError);
@@ -123,10 +125,11 @@ const Activity: FC = () => {
           limit: PAGE_SIZE,
           offset: 0,
         })
-          .then((bridges) => {
+          .then((response) => {
             callIfMounted(() => {
+              const { bridges, total } = response;
               processFetchBridgesSuccess(bridges);
-              setEndReached(bridges.length < PAGE_SIZE);
+              setEndReached(bridges.length === total);
             });
           })
           .catch(processFetchBridgesError);
@@ -160,10 +163,11 @@ const Activity: FC = () => {
           ethereumAddress: account.data,
           quantity: lastLoadedItem,
         })
-          .then((bridges) => {
+          .then((response) => {
             callIfMounted(() => {
+              const { bridges, total } = response;
               processFetchBridgesSuccess(bridges);
-              setEndReached(bridges.length < PAGE_SIZE);
+              setEndReached(bridges.length === total);
             });
           })
           .catch(processFetchBridgesError);

--- a/src/views/activity/components/infinite-scroll/infinite-scroll.view.tsx
+++ b/src/views/activity/components/infinite-scroll/infinite-scroll.view.tsx
@@ -2,22 +2,15 @@ import React from "react";
 
 import Spinner from "src/views/shared/spinner/spinner.view";
 import useInfiniteScrollStyles from "src/views/activity/components/infinite-scroll/infinite-scroll.styles";
-import { AsyncTask } from "src/utils/types";
 
 const TRESHOLD = 0.9;
 
 interface InfiniteScrollProps {
-  asyncTaskStatus: AsyncTask<never, never>["status"];
+  isLoading: boolean;
   onLoadNextPage: () => void;
-  endReached: boolean;
 }
 
-const InfiniteScroll: React.FC<InfiniteScrollProps> = ({
-  asyncTaskStatus,
-  endReached,
-  children,
-  onLoadNextPage,
-}) => {
+const InfiniteScroll: React.FC<InfiniteScrollProps> = ({ children, isLoading, onLoadNextPage }) => {
   const classes = useInfiniteScrollStyles();
   const [scrollReachedEnd, setScrollReachedEnd] = React.useState(false);
   const ref = React.useRef<HTMLDivElement | null>(null);
@@ -40,29 +33,27 @@ const InfiniteScroll: React.FC<InfiniteScrollProps> = ({
   }, [ref]);
 
   React.useEffect(() => {
-    if (scrollReachedEnd && asyncTaskStatus === "successful") {
+    if (scrollReachedEnd && !isLoading) {
       onLoadNextPage();
     }
     setScrollReachedEnd(false);
-  }, [asyncTaskStatus, scrollReachedEnd, onLoadNextPage]);
+  }, [isLoading, scrollReachedEnd, onLoadNextPage]);
+
+  React.useEffect(() => {
+    if (ref.current) {
+      const isScrollVisible = ref.current.getBoundingClientRect().height > window.innerHeight;
+      if (isScrollVisible === false) {
+        onLoadNextPage();
+      }
+    }
+  }, [onLoadNextPage]);
 
   return (
     <div className={classes.root} ref={ref}>
       {children}
-      {endReached && asyncTaskStatus === "reloading" && (
+      {isLoading && (
         <div className={classes.spinnerWrapper}>
           <Spinner size={24} />
-        </div>
-      )}
-      {endReached === false && (
-        <div className={classes.loadMoreButtonWrapper}>
-          <button
-            className={classes.loadMoreButton}
-            onClick={onLoadNextPage}
-            disabled={asyncTaskStatus === "reloading"}
-          >
-            {asyncTaskStatus === "reloading" ? <Spinner size={20} color="white" /> : "Load More"}
-          </button>
         </div>
       )}
     </div>


### PR DESCRIPTION
Closes #111 

### What does this PR does?

This PR fixes the following:

- Rely on the `total_cnt` field returned by the API instead of on the length of the list of items returned.
- Improve `InfiniteScroll` component to fire when the scroll doesn't exist to avoid displaying a button on larger screens.
- Ask for the merkle proof when the user clicks the Finalise button
- Fix the bug that renders twice one item when you add an item and ask for the next page