### PR TITLE
Use MaxUint256 for ERC-20 token allowance approval

### DIFF
--- a/src/contexts/bridge.context.tsx
+++ b/src/contexts/bridge.context.tsx
@@ -664,7 +664,7 @@ const BridgeProvider: FC = (props) => {
           );
           const allowance = await erc20Contract.allowance(account.data, from.contractAddress);
           if (allowance.lt(amount)) {
-            await erc20Contract.approve(from.contractAddress, amount);
+            await erc20Contract.approve(from.contractAddress, ethersConstants.MaxUint256);
           }
         }
         return contract.bridge(token.address, amount, to.networkId, destinationAddress, overrides);


### PR DESCRIPTION
Closes #113

### What does this PR does?

This PR increments the ERC-20 token's allowance approval to be MaxUint256.